### PR TITLE
Correct paths for prepare_annovar_user.pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ See `setup.sh -h` to list the available options. By default, we do not install t
   - commands to build the annovar database
   
     ```bash
-    perl prepare_annovar_user.pl -dbtype cosmic CosmicMutantExport.tsv -vcf CosmicCodingMuts.vcf > hg19_cosmic_coding.txt
-    perl prepare_annovar_user.pl -dbtype cosmic CosmicNCV.tsv -vcf CosmicNonCodingVariants.vcf > hg19_cosmic_noncoding.txt
+    perl tools/annovar/prepare_annovar_user.pl -dbtype cosmic databases/CosmicMutantExport.tsv -vcf databases/CosmicCodingMuts.vcf > databases/hg19_cosmic_coding.txt
+    perl tools/annovar/prepare_annovar_user.pl -dbtype cosmic databases/CosmicNCV.tsv -vcf databases/CosmicNonCodingVariants.vcf > databases/hg19_cosmic_noncoding.txt
     ```
 
   - Move both created files to the annovar/humandb folder.


### PR DESCRIPTION
prepare_annovar_user.pl is in the annovar folder (tools/annovar) while the databases are located in the database folder. This means that the paths need to be adjusted to match that structure.