### PR TITLE
Fix #8 DGIdb link dead

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -202,7 +202,7 @@ function install_databases() {
   wget http://www.cancerhotspots.org/files/hotspots_v2.xls
 
   # DGIdb
-  wget http://www.dgidb.org/data/interactions.tsv -O DGIdb_interactions.tsv
+  wget https://www.dgidb.org/data/monthly_tsvs/2020-Oct/interactions.tsv -O DGIdb_interactions.tsv
 
   # Actionable alterations
   # wget https://oncokb.org/api/v1/utils/allActionableVariants.txt


### PR DESCRIPTION
Looks like the files are now provided on a monthly basis: https://www.dgidb.org/downloads
So I inserted a link to the most recent version (October 2020) into the file.